### PR TITLE
Struct erase test

### DIFF
--- a/src/mocks/SdkStorage.sol
+++ b/src/mocks/SdkStorage.sol
@@ -119,5 +119,7 @@ contract SdkStorage {
         for (uint160 i = 0; i < 4; i++) {
             delete maps.vects[address(i)];
         }
+
+        structs.pop();
     }
 }


### PR DESCRIPTION
Adds a struct `pop` to be matched in the Rust SDK