### PR TITLE
Error Recovery Policy

### DIFF
--- a/src/osp/OneStepProofEntry.sol
+++ b/src/osp/OneStepProofEntry.sol
@@ -117,7 +117,7 @@ contract OneStepProofEntry is IOneStepProofEntry {
         } else if (
             (opcode >= Instructions.GET_GLOBAL_STATE_BYTES32 &&
                 opcode <= Instructions.SET_GLOBAL_STATE_U64) ||
-            (opcode >= Instructions.READ_PRE_IMAGE && opcode <= Instructions.POP_ERROR_GUARD)
+            (opcode >= Instructions.READ_PRE_IMAGE && opcode <= Instructions.SET_ERROR_POLICY)
         ) {
             prover = proverHostIo;
         } else {
@@ -132,7 +132,7 @@ contract OneStepProofEntry is IOneStepProofEntry {
             mach.modulesRoot = modProof.computeRootFromModule(oldModIdx, mod);
         }
 
-        if (mach.status == MachineStatus.ERRORED && !mach.guardStack.empty()) {
+        if (mach.status == MachineStatus.ERRORED && mach.guardStack.canPop()) {
             ErrorGuard memory guard = mach.guardStack.pop();
             mach.frameStack.overwrite(guard.frameStack);
             mach.valueStack.overwrite(guard.valueStack);

--- a/src/osp/OneStepProverHostIo.sol
+++ b/src/osp/OneStepProverHostIo.sol
@@ -400,7 +400,6 @@ contract OneStepProverHostIo is IOneStepProver {
         Value memory onError = ValueLib.newPc(mach.functionPc, mach.functionIdx, mach.moduleIdx);
         mach.guardStack.push(GuardStackLib.newErrorGuard(frames, values, inters, onError));
         mach.valueStack.push(ValueLib.newI32(1));
-        mach.guardStack.enabled = true;
     }
 
     function executePopErrorGuard(
@@ -411,7 +410,6 @@ contract OneStepProverHostIo is IOneStepProver {
         bytes calldata
     ) internal pure {
         mach.guardStack.pop();
-        mach.guardStack.enabled = false;
     }
 
     function executeSetErrorPolicy(

--- a/src/precompiles/ArbDebug.sol
+++ b/src/precompiles/ArbDebug.sol
@@ -37,6 +37,8 @@ interface ArbDebug {
 
     function customRevert(uint64 number) external pure;
 
+    function panic() external;
+
     function legacyError() external pure;
 
     error Custom(uint64, string, bool);

--- a/src/precompiles/ArbOwner.sol
+++ b/src/precompiles/ArbOwner.sol
@@ -14,103 +14,103 @@ pragma solidity >=0.4.21 <0.9.0;
  * Precompiled contract that exists in every Arbitrum chain at 0x0000000000000000000000000000000000000070.
  **/
 interface ArbOwner {
-    // @notice Add account as a chain owner
+    /// @notice Add account as a chain owner
     function addChainOwner(address newOwner) external;
 
-    // @notice Remove account from the list of chain owners
+    /// @notice Remove account from the list of chain owners
     function removeChainOwner(address ownerToRemove) external;
 
-    // @notice See if the user is a chain owner
+    /// @notice See if the user is a chain owner
     function isChainOwner(address addr) external view returns (bool);
 
-    // @notice Retrieves the list of chain owners
+    /// @notice Retrieves the list of chain owners
     function getAllChainOwners() external view returns (address[] memory);
 
-    // @notice Set how slowly ArbOS updates its estimate of the L1 basefee
+    /// @notice Set how slowly ArbOS updates its estimate of the L1 basefee
     function setL1BaseFeeEstimateInertia(uint64 inertia) external;
 
-    // @notice Set the L2 basefee directly, bypassing the pool calculus
+    /// @notice Set the L2 basefee directly, bypassing the pool calculus
     function setL2BaseFee(uint256 priceInWei) external;
 
-    // @notice Set the minimum basefee needed for a transaction to succeed
+    /// @notice Set the minimum basefee needed for a transaction to succeed
     function setMinimumL2BaseFee(uint256 priceInWei) external;
 
-    // @notice Set the computational speed limit for the chain
+    /// @notice Set the computational speed limit for the chain
     function setSpeedLimit(uint64 limit) external;
 
-    // @notice Set the maximum size a tx (and block) can be
+    /// @notice Set the maximum size a tx (and block) can be
     function setMaxTxGasLimit(uint64 limit) external;
 
-    // @notice Set the L2 gas pricing inertia
+    /// @notice Set the L2 gas pricing inertia
     function setL2GasPricingInertia(uint64 sec) external;
 
-    // @notice Set the L2 gas backlog tolerance
+    /// @notice Set the L2 gas backlog tolerance
     function setL2GasBacklogTolerance(uint64 sec) external;
 
-    // @notice Get the network fee collector
+    /// @notice Get the network fee collector
     function getNetworkFeeAccount() external view returns (address);
 
-    // @notice Get the infrastructure fee collector
+    /// @notice Get the infrastructure fee collector
     function getInfraFeeAccount() external view returns (address);
 
-    // @notice Set the network fee collector
+    /// @notice Set the network fee collector
     function setNetworkFeeAccount(address newNetworkFeeAccount) external;
 
-    // @notice Set the infrastructure fee collector
+    /// @notice Set the infrastructure fee collector
     function setInfraFeeAccount(address newInfraFeeAccount) external;
 
-    // @notice Upgrades ArbOS to the requested version at the requested timestamp
+    /// @notice Upgrades ArbOS to the requested version at the requested timestamp
     function scheduleArbOSUpgrade(uint64 newVersion, uint64 timestamp) external;
 
-    // @notice Sets equilibration units parameter for L1 price adjustment algorithm
+    /// @notice Sets equilibration units parameter for L1 price adjustment algorithm
     function setL1PricingEquilibrationUnits(uint256 equilibrationUnits) external;
 
-    // @notice Sets inertia parameter for L1 price adjustment algorithm
+    /// @notice Sets inertia parameter for L1 price adjustment algorithm
     function setL1PricingInertia(uint64 inertia) external;
 
-    // @notice Sets reward recipient address for L1 price adjustment algorithm
+    /// @notice Sets reward recipient address for L1 price adjustment algorithm
     function setL1PricingRewardRecipient(address recipient) external;
 
-    // @notice Sets reward amount for L1 price adjustment algorithm, in wei per unit
+    /// @notice Sets reward amount for L1 price adjustment algorithm, in wei per unit
     function setL1PricingRewardRate(uint64 weiPerUnit) external;
 
-    // @notice Set how much ArbOS charges per L1 gas spent on transaction data.
+    /// @notice Set how much ArbOS charges per L1 gas spent on transaction data.
     function setL1PricePerUnit(uint256 pricePerUnit) external;
 
-    // @notice Sets the base charge (in L1 gas) attributed to each data batch in the calldata pricer
+    /// @notice Sets the base charge (in L1 gas) attributed to each data batch in the calldata pricer
     function setPerBatchGasCharge(int64 cost) external;
 
-    // @notice Sets the cost amortization cap in basis points
+    /// @notice Sets the cost amortization cap in basis points
     function setAmortizedCostCapBips(uint64 cap) external;
 
-    // @notice Releases surplus funds from L1PricerFundsPoolAddress for use
+    /// @notice Releases surplus funds from L1PricerFundsPoolAddress for use
     function releaseL1PricerSurplusFunds(uint256 maxWeiToRelease) external returns (uint256);
 
-    // @notice sets the amount of ink 1 gas buys
-    // @param price the conversion rate (must fit in a uint24)
+    /// @notice sets the amount of ink 1 gas buys
+    /// @param price the conversion rate (must fit in a uint24)
     function setInkPrice(uint32 price) external;
 
-    // @notice sets the maximum depth (in wasm words) a wasm stack may grow
+    /// @notice sets the maximum depth (in wasm words) a wasm stack may grow
     function setWasmMaxStackDepth(uint32 depth) external;
 
-    // @notice sets the number of free wasm pages a tx gets
+    /// @notice sets the number of free wasm pages a tx gets
     function setWasmFreePages(uint16 pages) external;
 
-    // @notice sets the base cost of each additional wasm page
+    /// @notice sets the base cost of each additional wasm page
     function setWasmPageGas(uint16 gas) external;
 
-    // @notice sets the ramp that drives exponential wasm memory costs
+    /// @notice sets the ramp that drives exponential wasm memory costs
     function setWasmPageRamp(uint64 ramp) external;
 
-    // @notice sets the maximum number of pages a wasm may allocate
+    /// @notice sets the maximum number of pages a wasm may allocate
     function setWasmPageLimit(uint16 limit) external view;
 
-    // @notice sets the added wasm call cost based on binary size
+    /// @notice sets the added wasm call cost based on binary size
     function setWasmCallScalar(uint16 gas) external view;
 
-    /// @notice Sets serialized chain config in ArbOS state
+    //// @notice Sets serialized chain config in ArbOS state
     function setChainConfig(string calldata chainConfig) external;
 
-    // Emitted when a successful call is made to this precompile
+    /// Emitted when a successful call is made to this precompile
     event OwnerActs(bytes4 indexed method, address indexed owner, bytes data);
 }

--- a/src/state/Deserialize.sol
+++ b/src/state/Deserialize.sol
@@ -206,6 +206,8 @@ library Deserialize {
         bytes32 remainingHash;
         (remainingHash, offset) = b32(proof, offset);
         ErrorGuard[] memory proved;
+
+        bool enabled = uint8(proof[offset]) == 2;
         if (proof[offset] != 0) {
             offset++;
             proved = new ErrorGuard[](1);
@@ -214,7 +216,7 @@ library Deserialize {
             offset++;
             proved = new ErrorGuard[](0);
         }
-        window = GuardStack({proved: proved, remainingHash: remainingHash});
+        window = GuardStack({proved: proved, remainingHash: remainingHash, enabled: enabled});
     }
 
     function moduleMemory(bytes calldata proof, uint256 startOffset)

--- a/src/state/GuardStack.sol
+++ b/src/state/GuardStack.sol
@@ -16,6 +16,7 @@ struct ErrorGuard {
 struct GuardStack {
     ErrorGuard[] proved;
     bytes32 remainingHash;
+    bool enabled;
 }
 
 library GuardStackLib {
@@ -50,14 +51,22 @@ library GuardStackLib {
     }
 
     function hash(GuardStack memory guards) internal pure returns (bytes32 h) {
+        string memory prefix = "Guard stack (off):";
+        if (guards.enabled) {
+            prefix = "Guard stack (on):";
+        }
         h = guards.remainingHash;
         for (uint256 i = 0; i < guards.proved.length; i++) {
-            h = keccak256(abi.encodePacked("Guard stack:", hash(guards.proved[i]), h));
+            h = keccak256(abi.encodePacked(prefix, hash(guards.proved[i]), h));
         }
     }
 
+    function canPop(GuardStack memory guards) internal pure returns (bool) {
+        return guards.enabled && !empty(guards);
+    }
+
     function empty(GuardStack memory guards) internal pure returns (bool) {
-        return guards.proved.length == 0 && guards.remainingHash == 0;
+        return guards.proved.length == 0 || guards.remainingHash == 0;
     }
 
     function peek(GuardStack memory guards) internal pure returns (ErrorGuard memory) {

--- a/src/state/Instructions.sol
+++ b/src/state/Instructions.sol
@@ -149,6 +149,7 @@ library Instructions {
     uint16 internal constant UNLINK_MODULE = 0x8024;
     uint16 internal constant PUSH_ERROR_GUARD = 0x8025;
     uint16 internal constant POP_ERROR_GUARD = 0x8026;
+    uint16 internal constant SET_ERROR_POLICY = 0x8027;
 
     uint256 internal constant INBOX_INDEX_SEQUENCER = 0;
     uint256 internal constant INBOX_INDEX_DELAYED = 1;


### PR DESCRIPTION
This PR introduces the ability for the replay machine to enable & disable the error guard stack.

When disable, errors are unguarded, inducing a chain halt on failure.

Additionally, this PR adopts changes informed by
- #22
