### PR TITLE
Cache Manager Tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@openzeppelin/contracts": "4.5.0",
     "@openzeppelin/contracts-upgradeable": "4.5.2",
     "patch-package": "^6.4.7",
-    "solady": "=0.0.182"
+    "solady": "0.0.182"
   },
   "private": false,
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@openzeppelin/contracts": "4.5.0",
     "@openzeppelin/contracts-upgradeable": "4.5.2",
     "patch-package": "^6.4.7",
-    "solady": "^0.0.182"
+    "solady": "=0.0.182"
   },
   "private": false,
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6931,7 +6931,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-solady@=0.0.182:
+solady@0.0.182:
   version "0.0.182"
   resolved "https://registry.yarnpkg.com/solady/-/solady-0.0.182.tgz#bd8c47f128a3a752358ad052782773966d74c400"
   integrity sha512-FW6xo1akJoYpkXMzu58/56FcNU3HYYNamEbnFO3iSibXk0nSHo0DV2Gu/zI3FPg3So5CCX6IYli1TT1IWATnvg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6931,7 +6931,7 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
-solady@^0.0.182:
+solady@=0.0.182:
   version "0.0.182"
   resolved "https://registry.yarnpkg.com/solady/-/solady-0.0.182.tgz#bd8c47f128a3a752358ad052782773966d74c400"
   integrity sha512-FW6xo1akJoYpkXMzu58/56FcNU3HYYNamEbnFO3iSibXk0nSHo0DV2Gu/zI3FPg3So5CCX6IYli1TT1IWATnvg==


### PR DESCRIPTION
This PR addresses the feedback from
- #36 

Included are
- `192-bit` bids
- Pause-gating `makeSpace` (wasn't necessary but may as well)
- Adding more events (`ArbOwner` had these but may as well be part of the contract too)
- Reordered event fields
- Pinned Solady